### PR TITLE
Apply chatgpt visual styling

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#343541" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <title>Local API Chats</title>
   </head>
   <body>

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -82,11 +82,11 @@ export default function App() {
   }
 
   return (
-    <div className="flex h-full bg-neutral-50 text-neutral-900">
-      <aside className="w-64 border-r bg-white p-3 flex flex-col gap-2">
+    <div className="flex h-full bg-[#343541] text-[#ECECF1]">
+      <aside className="w-64 shrink-0 border-r border-[#2A2B32] bg-[#202123] p-3 flex flex-col gap-2">
         <div className="flex items-center justify-between mb-2">
-          <h1 className="font-semibold">Profiles</h1>
-          <button className="text-sm px-2 py-1 rounded bg-neutral-200" onClick={() => {
+          <h1 className="text-sm font-semibold text-[#ECECF1]/80">Profiles</h1>
+          <button className="text-xs px-2 py-1 rounded-md bg-[#10a37f] text-white hover:bg-[#15b374] transition" onClick={() => {
             const name = prompt('Profile name?') || 'New Profile'
             const api_base_url = prompt('API Base URL (e.g. https://api.openai.com)') || ''
             const api_key = prompt('API Key?') || ''
@@ -97,54 +97,60 @@ export default function App() {
         </div>
         <div className="flex flex-col gap-1">
           {profiles.map(p => (
-            <button key={p.id} onClick={() => setActiveProfileId(p.id)} className={`text-left px-2 py-1 rounded ${activeProfileId === p.id ? 'bg-neutral-200' : 'hover:bg-neutral-100'}`}>
-              <div className="font-medium">{p.name}</div>
-              <div className="text-xs text-neutral-500 truncate">{p.api_base_url}</div>
+            <button key={p.id} onClick={() => setActiveProfileId(p.id)} className={`text-left px-2 py-2 rounded-md transition ${activeProfileId === p.id ? 'bg-[#343541] text-[#ECECF1]' : 'hover:bg-[#2A2B32] text-[#ECECF1]/90'}`}>
+              <div className="text-sm font-medium truncate">{p.name}</div>
+              <div className="text-[11px] text-[#8E8EA0] truncate">{p.api_base_url}</div>
             </button>
           ))}
         </div>
       </aside>
       <main className="flex-1 grid grid-rows-[auto_1fr_auto]">
-        <header className="border-b bg-white p-3 flex items-center gap-3">
-          <div className="font-semibold">{activeProfile?.name || 'Select a profile'}</div>
+        <header className="border-b border-[#2A2B32] bg-[#343541] p-3 flex items-center gap-3">
+          <div className="font-medium text-[#ECECF1]/90">{activeProfile?.name || 'Select a profile'}</div>
           <div className="ml-auto flex items-center gap-2 text-sm">
-            <select className="border rounded px-2 py-1 bg-white">
+            <select className="border border-[#565869] rounded-md px-2 py-1 bg-[#40414F] text-[#ECECF1]">
               <option value="">Model (auto)</option>
               {models.map((m, idx) => (
                 <option key={idx} value={m.id || m.name || String(m)}>{m.id || m.name || String(m)}</option>
               ))}
             </select>
-            <button className="px-2 py-1 rounded bg-neutral-200" onClick={() => setSettingsOpen(true)}>Settings</button>
+            <button className="px-2 py-1 rounded-md bg-[#40414F] text-[#ECECF1] border border-[#565869] hover:bg-[#4A4B57] transition" onClick={() => setSettingsOpen(true)}>Settings</button>
           </div>
         </header>
-        <section className="overflow-y-auto p-4 space-y-4">
-          {messages.map((m, idx) => (
-            <div key={idx} className="flex gap-3">
-              <div className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${m.role === 'assistant' ? 'bg-blue-600 text-white' : 'bg-neutral-300'}`}>{m.role[0].toUpperCase()}</div>
-              <div className="prose max-w-3xl">
-                {m.content && <p>{m.content}</p>}
-                {m.parts?.filter(p => p.type === 'image_url').map((p, i) => (
-                  <img key={i} src={(p as any).image_url.url} alt="uploaded" className="rounded border max-w-sm" />
-                ))}
+        <section className="overflow-y-auto">
+          <div className="mx-auto w-full max-w-3xl">
+            {messages.map((m, idx) => (
+              <div key={idx} className={`${m.role === 'assistant' ? 'bg-[#444654]' : 'bg-transparent'} w-full`}>
+                <div className="px-4 py-6">
+                  <div className="flex items-start gap-4">
+                    <div className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold ${m.role === 'assistant' ? 'bg-[#10a37f] text-white' : 'bg-[#40414F] text-[#ECECF1]'}`}>{m.role[0].toUpperCase()}</div>
+                    <div className="min-w-0 flex-1 whitespace-pre-wrap leading-relaxed text-[#ECECF1]">
+                      {m.content && <p>{m.content}</p>}
+                      {m.parts?.filter(p => p.type === 'image_url').map((p, i) => (
+                        <img key={i} src={(p as any).image_url.url} alt="uploaded" className="mt-3 rounded-md border border-[#2A2B32] max-w-sm" />
+                      ))}
+                    </div>
+                  </div>
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </section>
-        <footer className="border-t bg-white p-3">
+        <footer className="border-t border-[#2A2B32] bg-[#343541] p-4">
           <div className="max-w-3xl mx-auto">
             <div className="flex items-end gap-2">
               <div className="flex-1 relative">
-                <textarea value={input} onChange={e => setInput(e.target.value)} className="w-full resize-none rounded border p-3 pr-24" rows={3} placeholder="Message..." />
+                <textarea value={input} onChange={e => setInput(e.target.value)} className="w-full resize-none rounded-2xl border border-[#565869] bg-[#40414F] text-[#ECECF1] placeholder-[#9B9CA8] p-4 pr-28 focus:outline-none focus:ring-1 focus:ring-[#565869]" rows={3} placeholder="Message ChatGPT..." />
                 <div className="absolute right-2 bottom-2 flex items-center gap-2">
                   <input ref={fileInputRef} type="file" accept="image/*" onChange={handleUploadChange} className="hidden" />
-                  <button className="px-2 py-1 text-sm rounded bg-neutral-200" onClick={() => fileInputRef.current?.click()}>Upload</button>
-                  <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={handleSend}>Send</button>
+                  <button className="px-2 py-1 text-xs rounded-md bg-[#40414F] text-[#ECECF1] border border-[#565869] hover:bg-[#4A4B57] transition" onClick={() => fileInputRef.current?.click()}>Upload</button>
+                  <button className="px-3 py-2 rounded-md bg-[#10a37f] text-white hover:bg-[#15b374] transition" onClick={handleSend}>Send</button>
                 </div>
               </div>
             </div>
             {imageDataUrl && (
-              <div className="mt-2 text-sm text-neutral-600 flex items-center gap-2">
-                <img src={imageDataUrl} className="h-10 w-10 object-cover rounded border" />
+              <div className="mt-2 text-sm text-[#9B9CA8] flex items-center gap-2">
+                <img src={imageDataUrl} className="h-10 w-10 object-cover rounded border border-[#2A2B32]" />
                 <span>Image attached</span>
                 <button className="underline" onClick={() => setImageDataUrl(null)}>remove</button>
               </div>

--- a/apps/client/src/components/SettingsModal.tsx
+++ b/apps/client/src/components/SettingsModal.tsx
@@ -18,37 +18,37 @@ export default function SettingsModal({ open, onClose, initial, onSave }: Props)
   if (!open) return null
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center p-4">
-      <div className="bg-white rounded shadow-lg w-full max-w-lg">
-        <div className="border-b p-3 font-semibold">Profile Settings</div>
-        <div className="p-4 space-y-3">
-          <div className="grid grid-cols-2 gap-3 items-end">
-            <label className="text-sm">Temperature</label>
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+      <div className="bg-[#343541] text-[#ECECF1] rounded-lg shadow-2xl w-full max-w-lg border border-[#2A2B32]">
+        <div className="border-b border-[#2A2B32] p-4 font-semibold">Profile Settings</div>
+        <div className="p-4 space-y-4">
+          <div className="grid grid-cols-2 gap-4 items-end">
+            <label className="text-sm text-[#ECECF1]/80">Temperature</label>
             <div className="flex items-center gap-2">
-              <input type="number" min={0} max={2} step={0.1} value={temperature as any} onChange={e => setTemperature(e.target.value === '' ? '' : Number(e.target.value))} className="border rounded px-2 py-1 w-32" />
-              <label className="text-sm flex items-center gap-1">
-                <input type="checkbox" checked={include.temperature !== false} onChange={e => setInclude({ ...include, temperature: e.target.checked })} /> include
+              <input type="number" min={0} max={2} step={0.1} value={temperature as any} onChange={e => setTemperature(e.target.value === '' ? '' : Number(e.target.value))} className="border border-[#565869] rounded-md px-2 py-1 w-32 bg-[#40414F] text-[#ECECF1]" />
+              <label className="text-sm flex items-center gap-1 text-[#ECECF1]/80">
+                <input type="checkbox" className="accent-[#10a37f]" checked={include.temperature !== false} onChange={e => setInclude({ ...include, temperature: e.target.checked })} /> include
               </label>
             </div>
-            <label className="text-sm">Max context</label>
+            <label className="text-sm text-[#ECECF1]/80">Max context</label>
             <div className="flex items-center gap-2">
-              <input type="number" min={1} value={maxContext as any} onChange={e => setMaxContext(e.target.value === '' ? '' : Number(e.target.value))} className="border rounded px-2 py-1 w-32" />
-              <label className="text-sm flex items-center gap-1">
-                <input type="checkbox" checked={include.max_context !== false} onChange={e => setInclude({ ...include, max_context: e.target.checked })} /> include
+              <input type="number" min={1} value={maxContext as any} onChange={e => setMaxContext(e.target.value === '' ? '' : Number(e.target.value))} className="border border-[#565869] rounded-md px-2 py-1 w-32 bg-[#40414F] text-[#ECECF1]" />
+              <label className="text-sm flex items-center gap-1 text-[#ECECF1]/80">
+                <input type="checkbox" className="accent-[#10a37f]" checked={include.max_context !== false} onChange={e => setInclude({ ...include, max_context: e.target.checked })} /> include
               </label>
             </div>
-            <label className="text-sm">Max response tokens</label>
+            <label className="text-sm text-[#ECECF1]/80">Max response tokens</label>
             <div className="flex items-center gap-2">
-              <input type="number" min={1} value={maxTokens as any} onChange={e => setMaxTokens(e.target.value === '' ? '' : Number(e.target.value))} className="border rounded px-2 py-1 w-32" />
-              <label className="text-sm flex items-center gap-1">
-                <input type="checkbox" checked={include.max_output_tokens !== false} onChange={e => setInclude({ ...include, max_output_tokens: e.target.checked })} /> include
+              <input type="number" min={1} value={maxTokens as any} onChange={e => setMaxTokens(e.target.value === '' ? '' : Number(e.target.value))} className="border border-[#565869] rounded-md px-2 py-1 w-32 bg-[#40414F] text-[#ECECF1]" />
+              <label className="text-sm flex items-center gap-1 text-[#ECECF1]/80">
+                <input type="checkbox" className="accent-[#10a37f]" checked={include.max_output_tokens !== false} onChange={e => setInclude({ ...include, max_output_tokens: e.target.checked })} /> include
               </label>
             </div>
           </div>
         </div>
-        <div className="border-t p-3 flex justify-end gap-2">
-          <button className="px-3 py-1 rounded" onClick={onClose}>Cancel</button>
-          <button className="px-3 py-1 rounded bg-blue-600 text-white" onClick={() => onSave({ temperature: temperature === '' ? undefined : temperature, max_context: maxContext === '' ? undefined : maxContext, max_output_tokens: maxTokens === '' ? undefined : maxTokens, include_settings: include })}>Save</button>
+        <div className="border-t border-[#2A2B32] p-4 flex justify-end gap-2">
+          <button className="px-3 py-2 rounded-md border border-[#565869] bg-[#40414F] text-[#ECECF1] hover:bg-[#4A4B57] transition" onClick={onClose}>Cancel</button>
+          <button className="px-3 py-2 rounded-md bg-[#10a37f] text-white hover:bg-[#15b374] transition" onClick={() => onSave({ temperature: temperature === '' ? undefined : temperature, max_context: maxContext === '' ? undefined : maxContext, max_output_tokens: maxTokens === '' ? undefined : maxTokens, include_settings: include })}>Save</button>
         </div>
       </div>
     </div>

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -10,4 +10,10 @@ html, body, #root {
 
 body {
   font-family: var(--font-sans);
+  background-color: #343541;
+  color: #ECECF1;
+}
+
+html {
+  color-scheme: dark;
 }

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "types": ["react", "react-dom"]
+    "types": ["react", "react-dom", "react/jsx-runtime"]
   },
   "include": ["src"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3110,7 +3110,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3131,7 +3130,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3152,7 +3150,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3173,7 +3170,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3194,7 +3190,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3215,7 +3210,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3236,7 +3230,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3257,7 +3250,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3278,7 +3270,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3299,7 +3290,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
Implement ChatGPT-like dark theme and layout for the application's UI.

This PR updates the application's visual styles, including colors, font (Inter), and chat layout, to closely resemble the ChatGPT dark theme. Changes were applied to the main chat interface (sidebar, header, message area, composer) and the settings modal, ensuring no functional alterations.

---
<a href="https://cursor.com/background-agent?bcId=bc-1bd6f3a4-de6f-4b82-8cf5-c8f5521de8d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1bd6f3a4-de6f-4b82-8cf5-c8f5521de8d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

