### PR TITLE
Remove unnecessary api path segment

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -82,7 +82,7 @@ export default function App() {
 
     const debugEnabled = Boolean(profileSettings?.debug)
     if (debugEnabled) {
-      setDebugLogs(prev => [...prev, `[client] POST /api/chat`, JSON.stringify(requestBody, null, 2)])
+      setDebugLogs(prev => [...prev, `[client] POST /chat`, JSON.stringify(requestBody, null, 2)])
     }
 
     if (profileSettings?.stream) {
@@ -90,7 +90,7 @@ export default function App() {
       try {
         // Prepare placeholder assistant message
         setMessages(prev => [...prev, { role: 'assistant', content: '' }])
-        const resp = await fetch(`${API_BASE()}/api/chat`, {
+        const resp = await fetch(`${API_BASE()}/chat`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(requestBody)
@@ -182,7 +182,7 @@ export default function App() {
     }
 
     // Non-streaming fallback
-    const resp = await fetch(`${API_BASE()}/api/chat`, {
+    const resp = await fetch(`${API_BASE()}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(requestBody)

--- a/apps/client/src/lib/api.ts
+++ b/apps/client/src/lib/api.ts
@@ -19,7 +19,7 @@ export async function listModels(profileId: number) {
 }
 
 export async function sendChat(body: any) {
-  const r = await fetch(`${apiBase()}/api/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
+  const r = await fetch(`${apiBase()}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
   return r.json()
 }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -26,6 +26,9 @@ app.use('/api/profiles', profilesRouter);
 app.use('/api/chat', chatRouter);
 app.use('/api/upload', uploadRouter);
 
+// Backwards-compatible alias without /api prefix
+app.use('/chat', chatRouter);
+
 app.get('/api/health', (_req, res) => {
 	res.json({ ok: true });
 });


### PR DESCRIPTION
Add `/chat` server alias and update client calls to use it, removing the `/api` prefix from chat POST requests.

The existing `/api/chat` route remains intact for backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-455008a0-71e1-4081-959e-509957285a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-455008a0-71e1-4081-959e-509957285a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

