### PR TITLE
Debug chat api model disabled error

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -33,6 +33,7 @@ export default function App() {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [profileSettings, setProfileSettings] = useState<any>({})
   const [debugLogs, setDebugLogs] = useState<string[]>([])
+  const [selectedModel, setSelectedModel] = useState<string>('')
 
   useEffect(() => {
     fetch(`${API_BASE()}/api/profiles`).then(r => r.json()).then(setProfiles)
@@ -58,8 +59,16 @@ export default function App() {
       }
     }
     loadModels()
+    setSelectedModel('')
     return () => { isCancelled = true }
   }, [activeProfileId])
+
+  useEffect(() => {
+    if (!selectedModel && Array.isArray(models) && models.length > 0) {
+      const first = models[0]
+      setSelectedModel(first?.id || first?.name || String(first))
+    }
+  }, [models, selectedModel])
 
   const activeProfile = useMemo(() => profiles.find(p => p.id === activeProfileId) || null, [profiles, activeProfileId])
 
@@ -75,7 +84,7 @@ export default function App() {
     const requestBody = {
       profileId: activeProfileId,
       conversationId: conversationId ?? undefined,
-      model: undefined,
+      model: selectedModel || undefined,
       messages: [...messages, outgoing].map(m => ({ role: m.role, content: m.content, parts: m.parts })),
       params: profileSettings || {}
     }
@@ -231,7 +240,7 @@ export default function App() {
         <header className="border-b border-[#2A2B32] bg-[#343541] p-3 flex items-center gap-3">
           <div className="font-medium text-[#ECECF1]/90">{activeProfile?.name || 'Select a profile'}</div>
           <div className="ml-auto flex items-center gap-2 text-sm">
-            <select className="border border-[#565869] rounded-md px-2 py-1 bg-[#40414F] text-[#ECECF1]">
+            <select className="border border-[#565869] rounded-md px-2 py-1 bg-[#40414F] text-[#ECECF1]" value={selectedModel} onChange={e => setSelectedModel(e.target.value)}>
               <option value="">Model (auto)</option>
               {models.map((m, idx) => (
                 <option key={idx} value={m.id || m.name || String(m)}>{m.id || m.name || String(m)}</option>


### PR DESCRIPTION
Add client-side model selection and align the server's upstream request to the OpenAI Chat Completions schema to resolve `model_disabled` errors.

The `model_disabled` error indicated that the upstream API was not receiving an explicit or valid `model` parameter. This PR introduces a client-side model selector to ensure the `model` field is always sent. Additionally, it refines the server's upstream request payload by removing non-standard parameters like `max_context` and `top_k`, and improves error parsing, making it more compatible with strict OpenAI-like APIs, as observed in other frontends.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad1a8059-c5f9-4784-bee0-0b48847a863d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad1a8059-c5f9-4784-bee0-0b48847a863d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

